### PR TITLE
allow directories with .yaml or .yml files

### DIFF
--- a/bin/aws-security-groups
+++ b/bin/aws-security-groups
@@ -51,7 +51,7 @@ core.load_security_groups
 files = []
 if File.directory?(options[:config])
   puts options[:config]
-  files = Dir.glob("#{options[:config]}/*.yml")
+  files = Dir.glob("#{options[:config]}/*.{yaml,yml}")
 else
   files.push(options[:config])
 end


### PR DESCRIPTION
That last patch that accepted directories of files needed the files to end in .yml. This change will allow .yaml, too.
